### PR TITLE
Updated marshal encoder to order the object keys before rendering

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -1,6 +1,7 @@
 package ajson
 
 import (
+	"sort"
 	"strconv"
 )
 
@@ -63,7 +64,14 @@ func Marshal(node *Node) (result []byte, err error) {
 		case Object:
 			result = append(result, bracesL)
 			bValue = false
-			for key, child := range node.children {
+			keys := make([]string, 0)
+			for key, _ := range node.children {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+
+			for _, key := range keys {
+				child := node.children[key]
 				if bValue {
 					result = append(result, coma)
 				} else {

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,6 +1,7 @@
 package ajson
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -192,5 +193,27 @@ func TestMarshal_Errors(t *testing.T) {
 				t.Errorf("wrong result")
 			}
 		})
+	}
+}
+
+func TestMarshal_ObjectKeyOrdering(t *testing.T) {
+	in := map[string]interface{}{
+		"c": 123,
+		"a": map[string]interface{}{
+			"z": "bar",
+			"h": 123,
+		},
+		"b": 2.6,
+	}
+	expect := `{"a":{"h":123,"z":"bar"},"b":2.6,"c":123}`
+
+	ij, _ := json.Marshal(in)
+	node := Must(Unmarshal(ij))
+
+	value, err := Marshal(node)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if string(value) != expect {
+		t.Errorf("wrong result: '%s', expected '%s'", value, expect)
 	}
 }


### PR DESCRIPTION
In order to have consistent JSON output, when rendering out the Object type nodes through the encoder, this update orders the keys before writing the bytes so that all Properties are deterministic. This mimics the same behaviour as the built-in JSON marshaller: `json.Marshal`.