### PR TITLE
Fixed Node.Clone() to update the correct parents for children

### DIFF
--- a/node_mutations.go
+++ b/node_mutations.go
@@ -184,7 +184,9 @@ func (n *Node) clone() *Node {
 		dirty:    n.dirty,
 	}
 	for key, value := range n.children {
-		node.children[key] = value.clone()
+		clone := value.clone()
+		clone.parent = node
+		node.children[key] = clone
 	}
 	return node
 }


### PR DESCRIPTION
Modified Node.clone() to update the parent field of each child to point to it's cloned parent (instead of the original nodes as it was). Added a test to validate this.
Issue #73 